### PR TITLE
Fix: uv sync cause error due to mmcv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ notebooks
 resources/checkpoint/
 examples
 outputs
+.DS_Store
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     "jupyter>=1.1.1",
     "loguru>=0.7.3",
     "matplotlib>=3.10.6",
-    "mmcv-full>=1.7.2",
+    "mmcv>=2.0.0,<2.3.0",
+    "mmengine>=0.10,<0.11",
     "notebook>=7.4.7",
     "omegaconf>=2.3.0",
     "opencv-python>=4.12.0.88",
@@ -205,6 +206,9 @@ testpaths = [
 ]
 norecursedirs = []
 filterwarnings = []
+[tool.uv.extra-build-dependencies]
+clip = ["setuptools<82"]
+mmcv = ["setuptools<82"]
 
 [tool.uv.sources]
 clip = { git = "https://github.com/openai/CLIP.git" }

--- a/src/demark_world/models/model/modules/feat_prop.py
+++ b/src/demark_world/models/model/modules/feat_prop.py
@@ -4,25 +4,14 @@ BasicVSR++: Improving Video Super-Resolution with Enhanced Propagation and Align
 
 import torch
 import torch.nn as nn
+from mmengine.model import constant_init
 
 try:
-    from mmcv.cnn import constant_init
     from mmcv.ops import ModulatedDeformConv2d, modulated_deform_conv2d
-except:
+except Exception as exc:
     from loguru import logger
 
-    logger.warning("mmcv is not available, using a fallback implementation")
-    import torch
-    import torch.nn as nn
-    import torch.nn.functional as F
-
-    # Fallback: constant_init function
-    def constant_init(module, val=0, bias=0):
-        """Initialize module parameters with constant values."""
-        if hasattr(module, "weight") and module.weight is not None:
-            nn.init.constant_(module.weight, val)
-        if hasattr(module, "bias") and module.bias is not None:
-            nn.init.constant_(module.bias, bias)
+    logger.warning(f"mmcv.ops is not available, using a fallback implementation: {exc}")
 
     def _pair(v):
         if isinstance(v, tuple):

--- a/src/demark_world/models/model/modules/flow_comp.py
+++ b/src/demark_world/models/model/modules/flow_comp.py
@@ -3,7 +3,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.runner import load_checkpoint
+from mmengine.runner import load_checkpoint
+
 from demark_world.configs import SPYNET_CHECKPOINT_PATH, PHY_NET_CHECKPOINT_REMOTE_URL
 from demark_world.utils.download_utils import ensure_model_downloaded
 


### PR DESCRIPTION
## Summary

Fixes the `uv sync` failure caused by `mmcv`, related to #5.

This PR adjusts the dependency setup to avoid the current `mmcv` installation problem during `uv sync`, so the project environment can be created successfully.

## Changes

- updated dependency configuration to work around the current `mmcv` issue
- made `uv sync` complete successfully in the local development environment

## Notes

This is a temporary fix.

Because of the `mmcv` version / API differences, `docker compose` may still fail to run correctly. That compatibility issue is not fully resolved in this PR and will need to be handled in a follow-up update.

## Related

- Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies: replaced mmcv-full with mmcv and mmengine for improved architecture compatibility.
  * Extended .gitignore to exclude additional system and lock files.
  * Added build-time dependency constraints for enhanced package installation control.

* **Bug Fixes**
  * Improved error handling in feature propagation module with more detailed exception information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->